### PR TITLE
fix: 修复打包产物收集和 iOS 工程配置问题

### DIFF
--- a/buildSrc/src/main/kotlin/KotlinAndroidTemplate.kt
+++ b/buildSrc/src/main/kotlin/KotlinAndroidTemplate.kt
@@ -2,7 +2,7 @@ import com.android.build.api.dsl.ApkSigningConfig
 import com.android.build.api.dsl.ApplicationExtension
 import org.gradle.api.Project
 import org.gradle.api.artifacts.dsl.DependencyHandler
-import org.gradle.api.file.RegularFile
+import java.io.File
 import org.gradle.kotlin.dsl.configure
 import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidExtension
 
@@ -31,7 +31,19 @@ abstract class KotlinAndroidTemplate : KotlinTemplate<KotlinAndroidExtension>() 
     open fun ApplicationExtension.sign(): ApkSigningConfig? = null
     open fun ApplicationExtension.android() { }
 
-    val Project.originOutput: RegularFile get() = layout.buildDirectory.get().dir("outputs").dir("apk").dir("release").file("${project.name}-release.apk")
+    val Project.originOutput: File
+        get() {
+            val outputDir = layout.buildDirectory.get().dir("outputs").dir("apk").dir("release").asFile
+            val outputList = outputDir.listFiles { file ->
+                file.isFile && file.extension.equals("apk", true)
+            }?.sortedBy { it.name }.orEmpty()
+            return when {
+                outputList.size == 1 -> outputList.first()
+                else -> outputList.firstOrNull { it.name == "${project.name}-release.apk" }
+                    ?: outputList.firstOrNull()
+                    ?: outputDir.resolve("${project.name}-release.apk")
+            }
+        }
 
     final override fun Project.build(extension: KotlinAndroidExtension) {
         with(extension) {

--- a/ylcs-app/app/portal/ylcs-app.podspec
+++ b/ylcs-app/app/portal/ylcs-app.podspec
@@ -23,6 +23,8 @@ Pod::Spec.new do |spec|
         'KOTLIN_PROJECT_PATH' => ':ylcs-app:app:portal',
         'PRODUCT_MODULE_NAME' => 'ylcs_app',
     }
+    spec.dependency 'MMKV', '2.3.0'
+    spec.dependency 'SGQRCode', '4.1.0'
     spec.script_phases = [
         {
             :name => 'Build ylcs-app',

--- a/ylcs-app/desktopApp/build.gradle.kts
+++ b/ylcs-app/desktopApp/build.gradle.kts
@@ -84,6 +84,9 @@ template(object : KotlinMultiplatformTemplate() {
 
         // 复制桌面动态库
         val desktopCopyNativeLib by tasks.registering(CopyDesktopNativeTask::class)
+        desktopCopyNativeLib {
+            dependsOn(tasks.named("desktopJar"))
+        }
 
         if ("desktopPublish" in currentTaskName || "desktopArtifact" in currentTaskName) {
             tasks.named("prepareAppResources") {

--- a/ylcs-app/iosApp/Podfile
+++ b/ylcs-app/iosApp/Podfile
@@ -2,6 +2,6 @@ use_frameworks!
 
 target 'iosApp' do
     platform :ios, '16.0'
-    pod 'portal', :path => '../app/portal'
+    pod 'ylcs-app', :path => '../app/portal'
     pod 'YLCSCore', :path => '../iosApp/core'
 end

--- a/ylcs-app/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/ylcs-app/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -11,7 +11,7 @@
 		058557D9273AAEEB004C7B11 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 058557D8273AAEEB004C7B11 /* Preview Assets.xcassets */; };
 		0CA7C15B19CA6285F56A934A /* Pods_iosApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6A68E12988198F31788004B0 /* Pods_iosApp.framework */; };
 		2152FB042600AC8F00CF470E /* RachelApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2152FB032600AC8F00CF470E /* RachelApp.swift */; };
-		7555FF83242A565900829871 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7555FF82242A565900829871 /* ContentView.swift */; };
+		7555FF83242A565900829871 /* ComposeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7555FF82242A565900829871 /* ComposeView.swift */; };
 		77C13BA92DBBD41D0041C60F /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 77C13BA82DBBD41D0041C60F /* LaunchScreen.storyboard */; };
 		77EE07652DDE356C00821BED /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = 77EE07642DDE356C00821BED /* Lottie */; };
 /* End PBXBuildFile section */
@@ -24,7 +24,7 @@
 		6A68E12988198F31788004B0 /* Pods_iosApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_iosApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6E42177E3E605F508BA33338 /* Pods-iosApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iosApp.release.xcconfig"; path = "Target Support Files/Pods-iosApp/Pods-iosApp.release.xcconfig"; sourceTree = "<group>"; };
 		7555FF7B242A565900829871 /* ylcs.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ylcs.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		7555FF82242A565900829871 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		7555FF82242A565900829871 /* ComposeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposeView.swift; sourceTree = "<group>"; };
 		7555FF8C242A565B00829871 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		77C13BA82DBBD41D0041C60F /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		AB3632DC29227652001CCB65 /* Config.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
@@ -83,7 +83,7 @@
 			children = (
 				77C13BA82DBBD41D0041C60F /* LaunchScreen.storyboard */,
 				058557BA273AAA24004C7B11 /* Assets.xcassets */,
-				7555FF82242A565900829871 /* ContentView.swift */,
+				7555FF82242A565900829871 /* ComposeView.swift */,
 				7555FF8C242A565B00829871 /* Info.plist */,
 				2152FB032600AC8F00CF470E /* RachelApp.swift */,
 				058557D7273AAEEB004C7B11 /* Preview Content */,
@@ -249,7 +249,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				2152FB042600AC8F00CF470E /* RachelApp.swift in Sources */,
-				7555FF83242A565900829871 /* ContentView.swift in Sources */,
+				7555FF83242A565900829871 /* ComposeView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ylcs-app/iosApp/iosApp/ComposeView.swift
+++ b/ylcs-app/iosApp/iosApp/ComposeView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 import UIKit
-import portal
+import ylcs_app
 
 struct ComposeView: UIViewControllerRepresentable {
     let instance: IOSDelegateApplication

--- a/ylcs-app/iosApp/iosApp/RachelApp.swift
+++ b/ylcs-app/iosApp/iosApp/RachelApp.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 import MMKV
-import portal
+import ylcs_app
 
 @main
 struct RachelApp: App {


### PR DESCRIPTION
这个 PR 修复了几个和打包相关的问题：
- Android 打包产物依赖固定 APK 文件名
- Desktop 打包后的 native 库位置不对，可能导致程序无法启动
- iOS 工程里的 pod 名称、模块引用和 Xcode 文件引用不一致