### PR TITLE
fix: 修复 MOD 导入后当前播放列表崩溃

### DIFF
--- a/ylcs-app/app/music/src/commonMain/kotlin/love/yinlin/startup/StartupMusicPlayer.kt
+++ b/ylcs-app/app/music/src/commonMain/kotlin/love/yinlin/startup/StartupMusicPlayer.kt
@@ -144,7 +144,10 @@ class StartupMusicPlayer(pool: StartupPool) : AsyncStartup(pool) {
     private fun fetchCurrentPlaylist(list: Playlist): List<String> = when (list) {
         is Playlist.None -> emptyList()
         is Playlist.Default -> library.values.map { it.id }
-        is Playlist.User -> app.config.playlistLibrary[list.name]?.items?.fastFilter { it in library } ?: emptyList()
+        is Playlist.User -> app.config.playlistLibrary[list.name]?.items
+            ?.fastFilter { it in library }
+            ?.distinct()
+            ?: emptyList()
     }
 
     suspend fun updateMusicLibraryInfo(ids: List<String>) {

--- a/ylcs-module/compose/components/media/src/androidMain/kotlin/love/yinlin/media/MusicPlayer.android.kt
+++ b/ylcs-module/compose/components/media/src/androidMain/kotlin/love/yinlin/media/MusicPlayer.android.kt
@@ -226,22 +226,7 @@ class AndroidMusicPlayer(fetcher: MediaMetadataFetcher) : MusicPlayer(fetcher) {
     } ?: Unit
 
     override suspend fun updateNewMedias(medias: List<String>) = withMainPlayer {
-        var oldIndex = 0
-        val oldList: List<String> = musicList
-
-        // 遍历目标列表
-        for (newIndex in medias.indices) {
-            val newItem = medias[newIndex]
-
-            // 如果旧列表还没遍历完, 并且当前的新旧 item 匹配
-            // 说明这个媒体是老媒体, 且就在当前位置, 不需要做任何操作
-            if (oldIndex < oldList.size && newItem == oldList[oldIndex]) ++oldIndex
-            else {
-                // 如果不匹配, 或者旧列表已经遍历完了, 说明这是一个全新插入的媒体
-                val newMediaItem = buildMediaItem(newItem)
-                if (newMediaItem != null) it.addMediaItem(newIndex, newMediaItem)
-            }
-        }
+        it.replaceMediaItems(0, it.mediaItemCount, medias.mapNotNull(::buildMediaItem))
     } ?: Unit
 
     override suspend fun removeMedia(index: Int) = withMainPlayer {


### PR DESCRIPTION
## 关联 Issue

Closes #259

## 问题原因

MOD 导入完成后会刷新当前播放列表。Android 播放器原先通过逐项增量插入同步媒体列表，当曲库更新导致列表顺序变化时，旧算法会重复插入已有歌曲，最终让 Compose 的 LazyColumn 收到重复的歌曲 ID，触发 `Key "..." was already used` 崩溃。

此外，用户歌单数据本身可能包含重复歌曲 ID，刷新时也会直接传入播放器。

## 修复内容

- Android 播放器使用 `replaceMediaItems` 原子替换整个媒体列表，正确处理新增、删除和顺序变化，避免增量同步产生重复项。
- 生成用户歌单播放列表时去重，并继续过滤已不存在于曲库的歌曲，确保 UI key 唯一。

## 验证

- `git diff --check` 通过。
- Android 编译受当前环境未配置 Android SDK 影响，无法执行：缺少 `ANDROID_HOME` 或 `local.properties` 中的 `sdk.dir`。
- 桌面编译受仓库原生依赖目录缺少 `CMakeLists.txt` 及 mmkv 原生构建失败影响，未能完成。